### PR TITLE
you can omit the argument if you don't care about it

### DIFF
--- a/lib/time_compact/railtie.rb
+++ b/lib/time_compact/railtie.rb
@@ -1,6 +1,6 @@
 module TimeCompact
   class Railtie < ::Rails::Railtie
-    initializer 'time_compact' do |app|
+    initializer 'time_compact' do
       ActiveSupport.on_load(:action_view) do
         ActionView::Base.send :include, ::TimeCompact
       end


### PR DESCRIPTION
The `app` argument is extra
